### PR TITLE
Made instance variables private

### DIFF
--- a/src/main/java/com/surmize/textalytics/AnalyzedDocument.java
+++ b/src/main/java/com/surmize/textalytics/AnalyzedDocument.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AnalyzedDocument {
-    List<AnalyzedSentence> sentences;
-    int sentiment;
+    private List<AnalyzedSentence> sentences;
+    private int sentiment;
 
     public int getSentiment() {
         return sentiment;

--- a/src/main/java/com/surmize/textalytics/NamedEntity.java
+++ b/src/main/java/com/surmize/textalytics/NamedEntity.java
@@ -1,10 +1,10 @@
 package com.surmize.textalytics;
 
 public class NamedEntity {
-    String text;
-    int offsetBegin = 0;
-    int offsetEnd = 0;
-    String type;
+    private String text;
+    private int offsetBegin = 0;
+    private int offsetEnd = 0;
+    private String type;
 
 
     public NamedEntity(String text) {

--- a/src/main/java/com/surmize/textalytics/TextAnalyzer.java
+++ b/src/main/java/com/surmize/textalytics/TextAnalyzer.java
@@ -16,7 +16,7 @@ import static edu.stanford.nlp.ling.CoreAnnotations.*;
 
 public class TextAnalyzer {
 
-    StanfordCoreNLP pipeline;
+    private StanfordCoreNLP pipeline;
 
     public TextAnalyzer() {
         // creates a StanfordCoreNLP object, with POS tagging, lemmatization, NER, parsing, and coreference resolution


### PR DESCRIPTION
Since there are public getters and setters for all of the instance
variables, it would make sense to make the instance variables be
private, in order to control access to these variables a little bit more 
tightly.
